### PR TITLE
Add BDSandGeyser parameter descriptions + more default parameters

### DIFF
--- a/Plugins/TurboLibrary/FileData/Muunt/MapObj/ParamDatabase.cs
+++ b/Plugins/TurboLibrary/FileData/Muunt/MapObj/ParamDatabase.cs
@@ -10,8 +10,8 @@ namespace TurboLibrary
     {
         public static Dictionary<int, float[]> ParameterDefaults = new Dictionary<int, float[]>()
         {
-            { 1012, new float[8] { 0, 5, 0, 0, 0, 0, 0, 0} },  // Sanbo
-            { 1021, new float[8] { 0, 0, 1, 3, 100, 0, 0, 0} },  // Basabasa
+            { 1012, new float[8] { 0, 5, 0, 0, 0, 0, 0, 0 }},  // Sanbo
+            { 1021, new float[8] { 0, 0, 1, 3, 100, 0, 0, 0 }},  // Basabasa
             { 1036, new float[8] { 1, 0, 0, 0, 0, 0, 0, 0 }},  // PcBalloon
             { 1040, new float[8] { 1, 0, 0, 0, 0, 0, 0, 0 }},  // TowerKuribo
             { 4048, new float[8] { 0, 700, 2300, 400, 0, 0, 0, 0 }},  // BDSandGeyser

--- a/Plugins/TurboLibrary/FileData/Muunt/MapObj/ParamDatabase.cs
+++ b/Plugins/TurboLibrary/FileData/Muunt/MapObj/ParamDatabase.cs
@@ -10,8 +10,11 @@ namespace TurboLibrary
     {
         public static Dictionary<int, float[]> ParameterDefaults = new Dictionary<int, float[]>()
         {
-            { 1040, new float[8] { 1, 0, 0, 0, 0, 0, 0, 0 }},  // TowerKuribo
+            { 1012, new float[8] { 0, 5, 0, 0, 0, 0, 0, 0} },  // Sanbo
+            { 1021, new float[8] { 0, 0, 1, 3, 100, 0, 0, 0} },  // Basabasa
             { 1036, new float[8] { 1, 0, 0, 0, 0, 0, 0, 0 }},  // PcBalloon
+            { 1040, new float[8] { 1, 0, 0, 0, 0, 0, 0, 0 }},  // TowerKuribo
+            { 4048, new float[8] { 0, 700, 2300, 400, 0, 0, 0, 0 }},  // BDSandGeyser
         };
 
         public static Dictionary<int, string[]> ParameterObjs = new Dictionary<int, string[]>()
@@ -272,7 +275,7 @@ namespace TurboLibrary
         {    4042, new string[8] {"Fall Delay", null, null, null, null, null, null, null} },  // KaraPillar
         {    4043, new string[8] {"Unknown 1", "Unknown 2", "Unknown 3", null, null, null, null, null} },  // MpBoard
         {    4044, new string[8] {null, null, null, null, null, null, null, null} },  // ExDash
-        {    4048, new string[8] {"Unknown 1", "Unknown 2", "Delay between rise", "Unknown 4", null, null, null, null} },  // BDSandGeyser
+        {    4048, new string[8] {"Initial Delay", "Up Duration", "Delay between rise", "Geyser Height", null, null, null, null} },  // BDSandGeyser
         {    4050, new string[8] {"Unknown 1", "Unknown 2", "Shake speed", "Unknown 4", "Unknown 5", "Unknown 6", null, null} },  // VolMovRoadPlus
         {    4051, new string[8] {null, null, "Shake speed", "Unknown 4", "Unknown 5", "Unknown 6", null, null} },  // VolMovRoad
         {    4052, new string[8] {"Unknown 1", "Unknown 2", "Unknown 3", "Unknown 4", null, null, null, "Model Index"} },  // VolcanoPiece


### PR DESCRIPTION
Added a description for the three remaining unknown parameters for BDSandGeyser.

Added default values for:
- BDSandGeyser: up duration, delay between rise, height. These match the values in U Bone Dry Dunes
- Sanbo: Wait Cycle, matching the value in GCN Dry Dry Desert
- Basabasa: Spawn Count (custom, but should not be zero). Start Distance and space between match the values in N64 Yoshi Valley

I've also gone ahead and sorted the default values dictionary by objectID