### PR TITLE
Load window icon properly on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+#Rider/Idea options directory
+.idea/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/Track Studio/TrackStudio.csproj
+++ b/Track Studio/TrackStudio.csproj
@@ -80,6 +80,9 @@
 	  <Content Update="Lib\Fonts\OpenFontIcons.ttf">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
+	  <Content Update="Icon.ico">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
 	</ItemGroup>
   
 	<ItemGroup>

--- a/Track Studio/src/Program.cs
+++ b/Track Studio/src/Program.cs
@@ -51,6 +51,13 @@ namespace TrackStudio
             var wnd = new UIFramework.Framework(new MainWindow(argumentHandle), mode, asssemblyVersion);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 wnd.Icon = System.Drawing.Icon.ExtractAssociatedIcon(Assembly.GetExecutingAssembly().Location);
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                wnd.Icon = new System.Drawing.Icon(
+                    System.IO.File.Open(Path.Combine(assemblyDir, "Icon.ico"), FileMode.Open), 256, 256);
+            }
+
             wnd.VSync = OpenTK.VSyncMode.On;
             wnd.Run();
         }


### PR DESCRIPTION
- Update gitignore to add Rider options directory
- Add icon file to output directory
- Load icon file as file stream if running on Linux