### PR TITLE
Fix animated material preset crash

### DIFF
--- a/Plugins/CafeLibrary/Bfres/Editing/Nodes/ModelWrapper.cs
+++ b/Plugins/CafeLibrary/Bfres/Editing/Nodes/ModelWrapper.cs
@@ -1266,7 +1266,8 @@ namespace CafeLibrary
             void AddMaterialAnim(string fileName, Stream stream)
             {
                 MaterialAnim anim = new MaterialAnim();
-                anim.Import(new MemoryStream(stream.ToArray()), ResFile);
+                var data = stream.ToArray();
+                anim.Import(new MemoryStream(data), ResFile);
 
                 string name = Path.GetFileNameWithoutExtension(fileName);
                 string ext = Path.GetExtension(fileName);


### PR DESCRIPTION
- Fix a crash that occured when trying to apply a material preset which includes a material anim (due to the contents of the stream not correctly being stored an array)