### PR TITLE
Run shader .exe files with WINE on non-Windows platforms

### DIFF
--- a/Plugins/CafeLibrary/ShaderTools/ShaderLoaders/CafeShaderDecoder.cs
+++ b/Plugins/CafeLibrary/ShaderTools/ShaderLoaders/CafeShaderDecoder.cs
@@ -203,7 +203,7 @@ namespace CafeLibrary.Rendering
             else
             {
                 start.FileName = "wine";
-                start.Arguments += $"\'{Path.Combine(Runtime.ExecutableDir, "GFD", "gx2shader-decompiler.exe")}\' ";
+                start.Arguments += $"\"{Path.Combine(Runtime.ExecutableDir, "GFD", "gx2shader-decompiler.exe")}\" ";
             }
 
             start.WorkingDirectory = Path.Combine(Runtime.ExecutableDir, "GFD");
@@ -218,7 +218,6 @@ namespace CafeLibrary.Rendering
             start.RedirectStandardOutput = true;
             start.CreateNoWindow = true;
             start.WindowStyle = ProcessWindowStyle.Hidden;
-            Console.WriteLine(start.FileName + ' ' + start.Arguments);
             using (Process process = Process.Start(start))
             {
                 using (StreamReader reader = process.StandardOutput)
@@ -277,10 +276,10 @@ namespace CafeLibrary.Rendering
             else
             {
                 start.FileName = "wine";
-                start.Arguments += $"\'{Path.Combine(Runtime.ExecutableDir, "GFD", "spirv-cross.exe")}\' ";
+                start.Arguments += $"\"{Path.Combine(Runtime.ExecutableDir, "GFD", "spirv-cross.exe")}\" ";
             }
             start.WorkingDirectory = Runtime.ExecutableDir;
-            start.Arguments = $"{AddQuotesIfRequired(filePath)} {remapFlags} --no-es --extension GL_ARB_shader_storage_buffer_object --extension GL_ARB_separate_shader_objects --no-420pack-extension --no-support-nonzero-baseinstance --version 440 --output {AddQuotesIfRequired(output)}";
+            start.Arguments += $"{AddQuotesIfRequired(filePath)} {remapFlags} --no-es --extension GL_ARB_shader_storage_buffer_object --extension GL_ARB_separate_shader_objects --no-420pack-extension --no-support-nonzero-baseinstance --version 440 --output {AddQuotesIfRequired(output)}";
             start.UseShellExecute = false;
             start.RedirectStandardOutput = true;
             start.CreateNoWindow = true;

--- a/Plugins/CafeLibrary/ShaderTools/ShaderLoaders/CafeShaderDecoder.cs
+++ b/Plugins/CafeLibrary/ShaderTools/ShaderLoaders/CafeShaderDecoder.cs
@@ -7,6 +7,7 @@ using System.IO;
 using Toolbox.Core;
 using Toolbox.Core.IO;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using GLFrameworkEngine;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
@@ -197,8 +198,15 @@ namespace CafeLibrary.Rendering
                 File.WriteAllBytes(Path.Combine(Runtime.ExecutableDir,"GFD",stage.Name), stage.Data);
 
             ProcessStartInfo start = new ProcessStartInfo();
-            start.FileName = "GFD/gx2shader-decompiler.exe";
-            start.WorkingDirectory = System.IO.Path.Combine(Runtime.ExecutableDir, "GFD");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                start.FileName = "GFD/gx2shader-decompiler.exe";
+            else
+            {
+                start.FileName = "wine";
+                start.Arguments += "GFD/gx2shader-decompiler.exe ";
+            }
+
+            start.WorkingDirectory = Path.Combine(Runtime.ExecutableDir, "GFD");
             foreach (var stage in stages)
             {
                 if (!File.Exists(Path.Combine(Runtime.ExecutableDir,"GFD",stage.Name)))
@@ -263,7 +271,13 @@ namespace CafeLibrary.Rendering
             string remapFlags = "";
 
             ProcessStartInfo start = new ProcessStartInfo();
-            start.FileName = $"GFD/spirv-cross.exe";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                start.FileName = "GFD/spirv-cross.exe";
+            else
+            {
+                start.FileName = "wine";
+                start.Arguments += "GFD/spirv-cross.exe";
+            }
             start.WorkingDirectory = Runtime.ExecutableDir;
             start.Arguments = $"{AddQuotesIfRequired(filePath)} {remapFlags} --no-es --extension GL_ARB_shader_storage_buffer_object --extension GL_ARB_separate_shader_objects --no-420pack-extension --no-support-nonzero-baseinstance --version 440 --output {AddQuotesIfRequired(output)}";
             start.UseShellExecute = false;

--- a/Plugins/CafeLibrary/ShaderTools/ShaderLoaders/CafeShaderDecoder.cs
+++ b/Plugins/CafeLibrary/ShaderTools/ShaderLoaders/CafeShaderDecoder.cs
@@ -203,7 +203,7 @@ namespace CafeLibrary.Rendering
             else
             {
                 start.FileName = "wine";
-                start.Arguments += "GFD/gx2shader-decompiler.exe ";
+                start.Arguments += $"\'{Path.Combine(Runtime.ExecutableDir, "GFD", "gx2shader-decompiler.exe")}\' ";
             }
 
             start.WorkingDirectory = Path.Combine(Runtime.ExecutableDir, "GFD");
@@ -218,6 +218,7 @@ namespace CafeLibrary.Rendering
             start.RedirectStandardOutput = true;
             start.CreateNoWindow = true;
             start.WindowStyle = ProcessWindowStyle.Hidden;
+            Console.WriteLine(start.FileName + ' ' + start.Arguments);
             using (Process process = Process.Start(start))
             {
                 using (StreamReader reader = process.StandardOutput)
@@ -276,7 +277,7 @@ namespace CafeLibrary.Rendering
             else
             {
                 start.FileName = "wine";
-                start.Arguments += "GFD/spirv-cross.exe";
+                start.Arguments += $"\'{Path.Combine(Runtime.ExecutableDir, "GFD", "spirv-cross.exe")}\' ";
             }
             start.WorkingDirectory = Runtime.ExecutableDir;
             start.Arguments = $"{AddQuotesIfRequired(filePath)} {remapFlags} --no-es --extension GL_ARB_shader_storage_buffer_object --extension GL_ARB_separate_shader_objects --no-420pack-extension --no-support-nonzero-baseinstance --version 440 --output {AddQuotesIfRequired(output)}";


### PR DESCRIPTION
- Execute gx2shader-decompiler.exe and spirv-cross.exe with WINE if the platform isnt Windows to avoid crashes when trying to open Wii U files